### PR TITLE
Allow the user to specify which variant of a version to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Docker image publicly available on Docker Hub: https://hub.docker.com/r/cfplatfo
 * `test`: *Optional, default `false`* Set to `true` to use the [PyPI test server](https://testpypi.python.org/pypi).
 * `repository_url`: *Optional* Set to a another pypi server such as pypicloud.
 * `repository`: *Optional* Set to a special index-server if it is specified in `~/.pypirc`.
+* `python_version`: *Optional* If multiple files have been uploaded for a package (e.g. source tarballs and wheels), download the file for the specified version instead of the file that was first uploaded.
 
 ### Example
 ``` yaml
@@ -27,6 +28,7 @@ resources:
     username: user
     password: pass
     test: false
+    python_version: source
 ```
 
 ## `get`: Download the latest version

--- a/pypi_resource/pypi.py
+++ b/pypi_resource/pypi.py
@@ -48,4 +48,10 @@ def get_versions_from_pypi(input):
 
 def get_pypi_version_url(input, version):
     pypi_info = get_pypi_package_info(input)
-    return pypi_info['releases'][version][0]['url']
+    files = pypi_info['releases'][version]
+    if 'python_version' not in input['source']:
+        return files[0]['url']
+    for file in files:
+        if file['python_version'] == input['source']['python_version']:
+            return file['url']
+    raise LookupError("No %s download found" % input['source']['python_version'])


### PR DESCRIPTION
Sometimes not only source tarballs are uploaded, but wheels too. Instead
of always grabbing the first file returned, allow the user to specify
which variant they want.

Noticed when I tried to grab the uritemplate package with this resource, where
the first file returned is not the source tarball but a wheel.