### PR TITLE
Allow also authentication for 'in' task

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Docker image publicly available on Docker Hub: https://hub.docker.com/r/cfplatfo
 |`repository.repository_url` |[PyPI](https://upload.pypi.org/legacy)|optional         | url to a twine compatible repository for upload
 |`repository.username`       |-/-     |req. for uploads | username for PyPI server authentication
 |`repository.password`       |-/-     |req. for uploads | password for PyPI server authentication
-|`repository.authenticate`   |out     |optional         | set to `always` to authenticate to a private repository for check and download also
+|`repository.authenticate`   |out     |optional         | set to `in` to authenticate to a private repo for check and download only, `always` to authenticate to a private repository for upload, check and download.
 
 ### Deprecated parameters (since version 0.2.0)
 * `python_version`: gets mapped to `filename_match` if it's not a version number. `python_version` is now only used for the actual interpreter version to have a transparent mapping to pip.

--- a/pypi_resource/common.py
+++ b/pypi_resource/common.py
@@ -149,7 +149,7 @@ def merge_defaults(resconfig):
     if not isinstance(repository, dict):
         raise ValueError('ERROR: source.repository must be a dictionary (using names is deprecated).')
     repository.setdefault('authenticate', 'out')
-    assert repository['authenticate'] in ['out', 'always']
+    assert repository['authenticate'] in ['in', 'out', 'always']
 
     # move deprecated values from source to source.repository
     for key in ['username', 'password', 'repository_url', 'test']:

--- a/pypi_resource/pipio.py
+++ b/pypi_resource/pipio.py
@@ -121,7 +121,8 @@ def get_pypi_url(input, mode='in', kind='repository') -> Tuple[str, str]:
         url = repocfg[key]    
     url_parts = urlsplit(url)
 
-    if repocfg.get('authenticate', None) == 'always':
+    authenticate = repocfg.get('authenticate', None)
+    if authenticate == 'always' or authenticate == mode:
         host_login = '%s:%s@%s' % (
             repocfg.get('username', ''),
             repocfg.get('password', ''),

--- a/test/unittests.py
+++ b/test/unittests.py
@@ -86,10 +86,16 @@ class TestPypi(unittest.TestCase):
         input = {'source': {'repository': {'authenticate': 'always', 'username': 'u', 'password': 'p'}}}
         input = common.merge_defaults(input)
         self.assertEqual(pipio.get_pypi_url(input, 'in'), ('https://u:p@upload.pypi.org/legacy/', 'upload.pypi.org'))
+        self.assertEqual(pipio.get_pypi_url(input, 'out'), ('https://u:p@upload.pypi.org/legacy/', 'upload.pypi.org'))
 
         input = {'source': {'repository': {'username': 'u', 'password': 'p'}}}
         input = common.merge_defaults(input)
         self.assertEqual(pipio.get_pypi_url(input, 'in'), ('https://upload.pypi.org/legacy/', 'upload.pypi.org'))
+        self.assertEqual(pipio.get_pypi_url(input, 'out'), ('https://u:p@upload.pypi.org/legacy/', 'upload.pypi.org'))
+
+        input = {'source': {'repository': {'authenticate': 'in', 'username': 'u', 'password': 'p'}}}
+        input = common.merge_defaults(input)
+        self.assertEqual(pipio.get_pypi_url(input, 'in'), ('https://u:p@upload.pypi.org/legacy/', 'upload.pypi.org'))
         self.assertEqual(pipio.get_pypi_url(input, 'out'), ('https://upload.pypi.org/legacy/', 'upload.pypi.org'))
 
         input = {'source': {'repository': {


### PR DESCRIPTION
# What changes

It allows users to authenticate through the url only for `in` operations (`get` and `check`).

# Fixes

It fixes issue #25 