### PR TITLE
Set get retry configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ resources:
 ```
 
 ## `get`: Download the latest version
-No parameters.
-__TODO__
- * `version.version`: *Optional*, defaults to latest version
+* `version.version`: *Optional*, defaults to latest version
+* `count_retries`: *Optional* Number of maximum retry before the task fails. By default 20 times.
+* `delay_between_retries`: *Optional* Time to wait in sec between two iterations of retry. By default 3s.
 
 ### Additional files populated
  * `version`: [Python version number](https://www.python.org/dev/peps/pep-0440/) of the downloaded package
@@ -87,12 +87,18 @@ plan:
 ## `put`: Upload a new version
 * `glob`: *Required* A [glob](https://docs.python.org/2/library/glob.html) expression matching the package file to upload.
 
+### Note
+You can modify `count_retries` and `delay_between_retries` in `get_params` to give enough time to PyPi to make available your package.
+
 ### Example
 ```yaml
 plan:
 - put: my-pypi-package
   params:
     glob: 'task-out-folder/my_package-*.tar.gz'
+  get_params:
+    count_retries: 10
+    delay_between_retries: 30
 ```
 
 ## Development

--- a/pypi_resource/in_.py
+++ b/pypi_resource/in_.py
@@ -22,6 +22,10 @@ from . import common, pipio
 from .retry import retry_wrapper
 
 
+RETRIES = 20
+DELAY = 3
+
+
 def select_artefact_for_response(package_info, version: pipio.Version, artefact_index: int=0):
     """
     From the package_info returned by pip_get_version select a specific version/artefact and
@@ -47,7 +51,6 @@ def select_artefact_for_response(package_info, version: pipio.Version, artefact_
     }
 
 
-@retry_wrapper(20, 3)
 def download_version(resconfig, destdir):
     # fetch all matching versions/artifacts
     package_info = pipio.pip_get_versions(resconfig)
@@ -73,7 +76,10 @@ def in_(destdir, instream):
     resconfig = json.load(instream)
     common.merge_defaults(resconfig)
 
-    response = download_version(resconfig, destdir)
+    retries = resconfig['params'].get('count_retries', RETRIES)
+    delay = resconfig['params'].get('delay_between_retries', DELAY)
+    download = retry_wrapper(retries, delay)(download_version)
+    response = download(resconfig, destdir)
 
     # fetch metadata from download
     wheel = glob.glob(os.path.join(destdir, '*.whl'))

--- a/pypi_resource/in_.py
+++ b/pypi_resource/in_.py
@@ -52,8 +52,7 @@ def download_version(resconfig, destdir):
     # fetch all matching versions/artifacts
     package_info = pipio.pip_get_versions(resconfig)
     if not package_info:
-        common.msg("No matching packages found.")
-        return {}
+        raise ValueError("No matching packages found.")
 
     version = resconfig['version']['version']
     if not version:


### PR DESCRIPTION
# What changes

* It allows users to tune the retry mechanism in `get` step.
* It also raise an error when no package is found. This is necessary when a new package is uploaded, for a short amount of time (between upload and PyPi to make the package available), no package is found when calling the server.

# Fixes

It fixes issue #26 