### PR TITLE
Implement for `put` step a check on package names

### DIFF
--- a/pypi_resource/out.py
+++ b/pypi_resource/out.py
@@ -23,6 +23,10 @@ import sys
 from . import common, pipio
 
 
+class NamesValidationError(Exception):
+    pass
+
+
 def find_package(pattern, srcdir):
     files = glob.glob(os.path.join(srcdir, pattern))
     common.msg('Glob {} matched files: {}', pattern, files)
@@ -62,6 +66,16 @@ def out(srcdir, input):
     pkgpath = find_package(input['params']['glob'], srcdir)
     response = common.get_package_info(pkgpath)
     version = str(response['version'])
+
+    # Implement the check `input name = package name`
+    common.msg('Check that the package name = input name')
+    package_name = str(response['metadata']['package_name'])
+    input_name = str(input['source']['name'])
+    print(f"{package_name} <--> {input_name}")
+    if package_name != input_name:
+        raise NamesValidationError(
+            f"Different names for package ({package_name}) and input ({input_name})"
+        )
 
     common.msg('Uploading {} version {}', pkgpath, version)
     upload_package(pkgpath, input)

--- a/test/pypi-integration.py
+++ b/test/pypi-integration.py
@@ -75,10 +75,22 @@ class TestPut(unittest.TestCase):
         out.out(
             os.path.join(REPODIR, 'dist'),
             {
-                'source': {'test': True},
+                'source': {'test': True, 'name': 'concourse-pypi-resource'},
                 'params': {'glob': '*.tar.gz'}
             }
         )
+
+    def test_fail_to_upload_if_input_name_different_from_package_name(self):
+        rc = subprocess.run(['python', 'setup.py', 'sdist'], check=True, cwd=REPODIR)
+        print("sdist returned", rc)
+        with self.assertRaises(out.NamesValidationError) as context:
+            out.out(
+                os.path.join(REPODIR, 'dist'),
+                {
+                    'source': {'test': True, 'name': 'concourse-resource'},
+                    'params': {'glob': '*.tar.gz'}
+                }
+            )
 
 
 class TestPip(unittest.TestCase):


### PR DESCRIPTION
Check = input name == package name

Otherwise, the `get` step after the `put` step will fail, as the package
that will be search doesn't have the same name as the one tagged in the
uploaded package.

Issue to be fixed:
https://github.com/cf-platform-eng/concourse-pypi-resource/issues/32