### PR TITLE
PCI-1473 Verify version is PEP440 compliant

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 pkginfo = "*"
 twine = "*"
 pip = "*"
+pep440 = "*"
 setuptools = "*"
 
 [dev-packages]

--- a/pypi_resource/out.py
+++ b/pypi_resource/out.py
@@ -21,7 +21,10 @@ import subprocess
 import sys
 
 from . import common, pipio
+from pep440 import is_canonical
 
+class VersionValidationError(Exception):
+    pass
 
 def find_package(pattern, srcdir):
     files = glob.glob(os.path.join(srcdir, pattern))
@@ -62,6 +65,11 @@ def out(srcdir, input):
     pkgpath = find_package(input['params']['glob'], srcdir)
     response = common.get_package_info(pkgpath)
     version = str(response['version'])
+
+    if not is_canonical(version):
+        raise VersionValidationError(
+            f"Version {version} string is not compliant with PEP 440 versioning convention"
+        )
 
     common.msg('Uploading {} version {}', pkgpath, version)
     upload_package(pkgpath, input)

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     install_requires = [
         'pkginfo',
         'twine',
+        'pep440',
         'pip',
     ],
     setup_requires = [],

--- a/test/pypi-integration.py
+++ b/test/pypi-integration.py
@@ -80,6 +80,17 @@ class TestPut(unittest.TestCase):
             }
         )
 
+    def test_fail_to_upload_if_package_version_not_pep440_compliant(self):
+        rc = subprocess.run(['python', 'setup.py', 'sdist'], check=True, cwd=os.path.join(THISDIR, 'test_package1_4'))
+        print("sdist returned", rc)
+        with self.assertRaises(out.NamesValidationError):
+            out.out(
+                os.path.join(REPODIR, 'dist'),
+                {
+                    'source': {'test': True, 'name': 'concourse-resource'},
+                    'params': {'glob': '*.tar.gz'}
+                }
+            )
 
 class TestPip(unittest.TestCase):
 

--- a/test/test_package1_4/README
+++ b/test/test_package1_4/README
@@ -1,0 +1,1 @@
+File to test repository interaction.

--- a/test/test_package1_4/setup.py
+++ b/test/test_package1_4/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+
+setup(
+    name = "test_package1",
+    version = '0.0.0-343-gea3bdad',
+    description = 'Repository IO Test-Package.',
+    platforms = ['linux'],
+    license = 'Apache 2.0',
+    include_package_data = True,
+    packages = ['test_package4',]
+)

--- a/test/test_package1_4/test_package4/main.py
+++ b/test/test_package1_4/test_package4/main.py
@@ -1,0 +1,4 @@
+from __future__ import print_function
+
+if __name__ == 'main':
+    print(__package__)


### PR DESCRIPTION
Verify that the package version is PEP440 compliant otherwise an error is raised and package is not uploaded to the server. Non PEP440 compliant version can not be fetched in get step, therefore enforcing the same limitation on the put step makes the resource a little bit more consistent. 

Issue to be fixed:
https://github.com/cf-platform-eng/concourse-pypi-resource/issues/30