### PR TITLE
Merge TWINE environmental variables with existing

### DIFF
--- a/pypi_resource/out.py
+++ b/pypi_resource/out.py
@@ -50,15 +50,18 @@ def upload_package(pkgpath, input):
 
     twine_cmd.append(pkgpath)
 
+    env = os.environ.copy()
+    env.update({
+        'TWINE_USERNAME': username,
+        'TWINE_PASSWORD': password,
+        'TWINE_REPOSITORY_URL': url
+    })
+
     subprocess.run(
         twine_cmd,
         stdout=sys.stderr.fileno(),
         check=True,
-        env={
-            'TWINE_USERNAME': username,
-            'TWINE_PASSWORD': password,
-            'TWINE_REPOSITORY_URL': url
-        }
+        env=env
     )
 
 


### PR DESCRIPTION
Concourse agent may have specified additional environmental variables, e.g. `HTTP_PROXY`, which are required for twine to run successfully.  This commit fixes this issue by merging the existing environmental variables with the process call.